### PR TITLE
Use the correct SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cordova-android"
   ],
   "author": "Apache Software Foundation",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ionic-team/cordova-plugin-ionic-keyboard/issues"
   },


### PR DESCRIPTION
The license field in package.json should use a SPDX identifier for the license. https://docs.npmjs.com/files/package.json#license
"Apache 2.0" isn't quiet right according to https://spdx.org/licenses/
This breaks license checks plugins that do rather strict matching of the id.

The project root also contains a copy of the MIT license in LICENSE.md. Shouldn't that be Apache 2.0 as well?