### PR TITLE
Configure keyboard view delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ cordova plugin add cordova-plugin-ionic-keyboard --save
 
 ## Preferences
 
+### KeyboardDelayDuration (for IOS Only)
+
+When styling your app like the Login page with (vh). The keyboard open delay might not be desirable. So this option can be used to configure the delay in which the keyboard is open.
+
+> Double (0.2 by default)
+
+```xml
+<preference name="KeyboardDelayDuration" value="0.2" />
+```
+
 ### KeyboardResize (for iOS only)
 
 > Boolean (true by default)

--- a/src/ios/CDVIonicKeyboard.m
+++ b/src/ios/CDVIonicKeyboard.m
@@ -155,10 +155,19 @@ NSString* UITraitsClassString;
     }
     CGRect rect = [[note.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     double height = rect.size.height;
+    double delayedDuration = 0.2;
+
+    NSDictionary *settings = self.commandDelegate.settings;
+    NSString *delayDurationString = [settings cordovaSettingForKey:@"KeyboardDelayDuration"];
+
+    if (delayDurationString) {
+        // convert string into double
+        delayedDuration = [delayDurationString doubleValue];
+    }
 
     if (self.isWK) {
         double duration = [[note.userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
-        [self setKeyboardHeight:height delay:duration+0.2];
+        [self setKeyboardHeight:height delay:duration+delayedDuration];
         [self resetScrollView];
     }
     


### PR DESCRIPTION
I had an encounter with your keyboard today and it has a delay until the Keyboard resizes the view. So I added a configurable option, so developers can modify the delay however they desire.