### PR TITLE
Fix content overflow below navigation bar, and black bar above the keyboard when it is shown

### DIFF
--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -15,6 +15,7 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
+import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
 
 // import additionally required classes for calculating screen height
@@ -125,13 +126,7 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         private void possiblyResizeChildOfContent() {
                             int usableHeightNow = computeUsableHeight();
                             if (usableHeightNow != usableHeightPrevious) {
-                                int usableHeightSansKeyboard = mChildOfContent.getRootView().getHeight();
-                                int heightDifference = usableHeightSansKeyboard - usableHeightNow;
-                                if (heightDifference > (usableHeightSansKeyboard/4)) {
-                                    frameLayoutParams.height = usableHeightSansKeyboard - heightDifference;
-                                } else {
-                                    frameLayoutParams.height = usableHeightSansKeyboard;
-                                }
+                                frameLayoutParams.height = usableHeightNow;
                                 mChildOfContent.requestLayout();
                                 usableHeightPrevious = usableHeightNow;
                             }
@@ -140,7 +135,28 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         private int computeUsableHeight() {
                             Rect r = new Rect();
                             mChildOfContent.getWindowVisibleDisplayFrame(r);
-                            return (r.bottom - r.top);
+
+                            /*
+                              Child content getWindowVisibleDisplayFrame return the area which the user can view the content.
+                              The top position is below the status bar. The bottom position is above the navigation bar, keyboard 
+                              and other UI element from the bottom.
+
+                              If app is in full screen mode, then the actual usable height is the distance from the top of the
+                              screen to the bottom of the Rect.
+
+                              SO:
+                              If app is in full screen, return the bottom position of the rect.
+
+                              If app is not in full screen, then should use the height of the visible area
+                             */
+                            return isFullScreen() ? r.bottom : r.height();
+                        }
+
+                        private boolean isFullScreen() {
+                            final Window window = cordova.getActivity().getWindow();
+                            // Flag set by status bar plugin to make content full screen
+                            int fullScreenFlag = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                            return (window.getDecorView().getSystemUiVisibility() & fullScreenFlag) == fullScreenFlag;
                         }
                     };
 


### PR DESCRIPTION
Fix for
#117
#132

Both of these issues are due to incorrect calculation of the frameLayoutParams.height value

Child content ``getWindowVisibleDisplayFrame()`` calculates the area which the user can view the content.

The top position is below the status bar. The bottom position is above the navigation bar, keyboard and other UI element from the bottom.

If app is in full screen mode, then the actual usable height is the distance from the top of the screen to the bottom of the returned Rect.

So, if app is in full screen, return the bottom position of the rect. Otherwise use the height of the visible area.