### PR TITLE
Android: incorrect keyboard height on devices with cutouts

### DIFF
--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -15,6 +15,7 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
+import android.view.WindowInsets;
 import android.view.inputmethod.InputMethodManager;
 
 // import additionally required classes for calculating screen height
@@ -90,18 +91,20 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                             // cache properties for later use
                             int rootViewHeight = rootView.getRootView().getHeight();
                             int resultBottom = r.bottom;
-
-                            // calculate screen height differently for android versions >= 21: Lollipop 5.x, Marshmallow 6.x
-                            //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5
                             int screenHeight;
 
-                            if (Build.VERSION.SDK_INT >= 21) {
+                            if (Build.VERSION.SDK_INT >= 23) {
+                              WindowInsets windowInsets = rootView.getRootWindowInsets();
+                              int stableInsetBottom = windowInsets.getStableInsetBottom();
+                              screenHeight = rootViewHeight;
+                              resultBottom = resultBottom + stableInsetBottom;
+                            } else {
+                                // calculate screen height differently for android versions <23: Lollipop 5.x, Marshmallow 6.x
+                                //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5
                                 Display display = cordova.getActivity().getWindowManager().getDefaultDisplay();
                                 Point size = new Point();
                                 display.getSize(size);
                                 screenHeight = size.y;
-                            } else {
-                                screenHeight = rootViewHeight;
                             }
 
                             int heightDiff = screenHeight - resultBottom;


### PR DESCRIPTION
This is a backport of a fix made for the same plugin code found in capacitor.

The original code is here: https://github.com/ionic-team/capacitor/pull/2924

Fixes #157 

Supersedes #133 

