### PR TITLE
Correct Android Screen Size (resizeOnFullScreen true - not full screen)

### DIFF
--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -15,6 +15,7 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
+import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
 
 // import additionally required classes for calculating screen height
@@ -125,13 +126,7 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         private void possiblyResizeChildOfContent() {
                             int usableHeightNow = computeUsableHeight();
                             if (usableHeightNow != usableHeightPrevious) {
-                                int usableHeightSansKeyboard = mChildOfContent.getRootView().getHeight();
-                                int heightDifference = usableHeightSansKeyboard - usableHeightNow;
-                                if (heightDifference > (usableHeightSansKeyboard/4)) {
-                                    frameLayoutParams.height = usableHeightSansKeyboard - heightDifference;
-                                } else {
-                                    frameLayoutParams.height = usableHeightSansKeyboard;
-                                }
+                                frameLayoutParams.height = usableHeightNow;
                                 mChildOfContent.requestLayout();
                                 usableHeightPrevious = usableHeightNow;
                             }
@@ -140,7 +135,14 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         private int computeUsableHeight() {
                             Rect r = new Rect();
                             mChildOfContent.getWindowVisibleDisplayFrame(r);
-                            return (r.bottom - r.top);
+                            return isFullScreen() ? r.bottom - r.top : r.height();
+                        }
+
+                        private boolean isFullScreen() {
+                            final Window window = cordova.getActivity().getWindow();
+                            // Flag set by status bar plugin to make content full screen
+                            int fullScreenFlag = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                            return (window.getDecorView().getSystemUiVisibility() & fullScreenFlag) == fullScreenFlag;
                         }
                     };
 


### PR DESCRIPTION
If you set the preference for resizeOnFullScreen and you do not have your app running (or you allow user settings) in either fullscreen mode (via StatusBar) or Immersive fullscreen mode (via cordova-plugin-fullscreen) the height is calculated wrong and some content between 8 and 40 pixels dependant on device will be off the bottom of the screen. This update looks for isFullScreen as per #156, which was close but we still need to subtract the r.top from the return value hence this PR which has been tested on many devices with and without statusbar and immersive mode.

Based on and fixes #156, #117, #132, #134