### PR TITLE
Allow to enable/disable AdjustScrollView

### DIFF
--- a/src/ios/CDVIonicKeyboard.m
+++ b/src/ios/CDVIonicKeyboard.m
@@ -113,7 +113,9 @@ NSString* UITraitsClassString;
         NSLog(@"CDVIonicKeyboard: WARNING!!: Keyboard plugin works better with WK");
     }
 
-    if (isWK) {
+    BOOL disabledAdjustScrollView = ![settings cordovaBoolSettingForKey:@"AdjustScrollView" defaultValue:YES];
+
+    if (isWK && disabledAdjustScrollView) {
         [nc removeObserver:self.webView name:UIKeyboardWillHideNotification object:nil];
         [nc removeObserver:self.webView name:UIKeyboardWillShowNotification object:nil];
         [nc removeObserver:self.webView name:UIKeyboardWillChangeFrameNotification object:nil];


### PR DESCRIPTION
Default behaviour on iOS is that when control is focused, it is scrolled up to the screen that the keyboard which pops up at the bottom doesn't cover the input control. When using this plugin behaviour is slightly changed - it scroll control up the screen but after a while it scrolls down. It relates to the adjustments being made by the plugin when keyboard is shown.

This change allows to enable/disable this adjustment via settings (AdjustScrollView).