### PR TITLE
[fix][iOS 17 beta] screen not scrolled when keyboard displayed on IOS 17 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ This plugin has been designed to work seamlessly with `cordova-plugin-ionic-webv
  - https://github.com/ionic-team/cordova-plugin-ionic-webview
  - https://ionicframework.com/docs/wkwebview/
 
+## Purpose of this fork
+- Fix screen not scrolled when keyboard displayed on IOS 17 beta
+
 ## Installation
 
 ```
-cordova plugin add cordova-plugin-ionic-keyboard --save
+cordova plugin add https://github.com/powowbox/cordova-plugin-ionic-keyboard.git --save --noregistery
 ```
 
 ## Preferences

--- a/src/ios/CDVIonicKeyboard.m
+++ b/src/ios/CDVIonicKeyboard.m
@@ -155,6 +155,10 @@ NSString* UITraitsClassString;
     }
     CGRect rect = [[note.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     double height = rect.size.height;
+    if ( height < 100 ) {
+        // SPI 07/07/23 fix for ios 17 beta. The callback trigger a first time with height 44 => the page is not scrolled correctly
+        return;
+    }
 
     if (self.isWK) {
         double duration = [[note.userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
@@ -172,6 +176,10 @@ NSString* UITraitsClassString;
 {
     CGRect rect = [[note.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     double height = rect.size.height;
+    if ( height < 100 ) {
+        // SPI 07/07/23 fix for ios 17 beta. The callback trigger a first time with height 44 => the page is not scrolled correctly
+        return;
+    }
 
     if (self.isWK) {
         [self resetScrollView];


### PR DESCRIPTION
Perhaps the issue will be fix on the final version of iOS 17. If it shouldn't be the case, here is a fix.

The keyboard height is not correct the first time callbacks onKeyboardWillShow and onKeyboardDidShow are displayed. The value is 44 instead of  an awaited value around 300.

Since the next time the callbacks are called, the height value is correct, it seems enough to ignore the first calls by setting a guard when the keyboard height is too low to be the right one.