### PR TITLE
fix: android keyboard size and square viewport

### DIFF
--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -28,6 +28,7 @@ public class CDVIonicKeyboard extends CordovaPlugin {
     private View rootView;
     private View mChildOfContent;
     private int usableHeightPrevious;
+    private int previosOrientation;
     private FrameLayout.LayoutParams frameLayoutParams;
 
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -38,7 +39,6 @@ public class CDVIonicKeyboard extends CordovaPlugin {
         if ("hide".equals(action)) {
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
-                    //http://stackoverflow.com/a/7696791/1091751
                     InputMethodManager inputManager = (InputMethodManager) cordova.getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
                     View v = cordova.getActivity().getCurrentFocus();
 
@@ -124,16 +124,26 @@ public class CDVIonicKeyboard extends CordovaPlugin {
 
                         private void possiblyResizeChildOfContent() {
                             int usableHeightNow = computeUsableHeight();
+                            int orientationNow = computeOrientation();
                             if (usableHeightNow != usableHeightPrevious) {
                                 int usableHeightSansKeyboard = mChildOfContent.getRootView().getHeight();
                                 int heightDifference = usableHeightSansKeyboard - usableHeightNow;
-                                if (heightDifference > (usableHeightSansKeyboard/4)) {
-                                    frameLayoutParams.height = usableHeightSansKeyboard - heightDifference;
-                                } else {
-                                    frameLayoutParams.height = usableHeightSansKeyboard;
+                                int height = usableHeightNow;
+
+                                if (heightDifference < 0) {
+                                    height = usableHeightNow;
                                 }
+                                else if (heightDifference > (usableHeightSansKeyboard/4)) {
+                                    height = usableHeightSansKeyboard - heightDifference;
+                                } else {
+                                    height = usableHeightSansKeyboard;
+                                }
+
+                                frameLayoutParams.height = height;
+
                                 mChildOfContent.requestLayout();
                                 usableHeightPrevious = usableHeightNow;
+                                previosOrientation = orientationNow;
                             }
                         }
 
@@ -141,6 +151,17 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                             Rect r = new Rect();
                             mChildOfContent.getWindowVisibleDisplayFrame(r);
                             return (r.bottom - r.top);
+                        }
+
+                        private int computeOrientation() {
+                            int h = mChildOfContent.getRootView().getHeight();
+                            int w = mChildOfContent.getRootView().getWidth();
+
+                            if(w < h){
+                                return 0;
+                            }else { 
+                                return 1;
+                            }
                         }
                     };
 


### PR DESCRIPTION
**Description:**
On some Android devices, there is an issue with the calculation of keyboard size, leading to an undesired viewport behavior. Specifically, when rapidly switching the device's orientation from landscape to portrait and back to landscape, the viewport becomes minimized to a black square. The side length of this square matches the device's portrait width.

This issue has persisted for several years and significantly impacts the user experience on affected Android devices.

**Reproduction Steps:**
1. Start with an Android device in landscape mode.
2. Rapidly switch the device to portrait mode.
3. Quickly switch the device back to landscape mode.
4. Observe the viewport becoming a black square, with a side length equal to the device's portrait width (a).

P.S.
I can try to provide screenshots if necessary.