### PR TITLE
Fixed DEV-23290 [KM PCMT] Footer Layout Appears Expanded With Excess Spacing Between Action Buttons and Navigation Icons

### DIFF
--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -15,6 +15,7 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
+import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
 
 // import additionally required classes for calculating screen height
@@ -64,7 +65,7 @@ public class CDVIonicKeyboard extends CordovaPlugin {
         if ("init".equals(action)) {
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
-                	//calculate density-independent pixels (dp)
+                    //calculate density-independent pixels (dp)
                     //http://developer.android.com/guide/practices/screens_support.html
                     DisplayMetrics dm = new DisplayMetrics();
                     cordova.getActivity().getWindowManager().getDefaultDisplay().getMetrics(dm);
@@ -114,7 +115,7 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                                 callbackContext.sendPluginResult(result);
                             }
                             else if ( pixelHeightDiff != previousHeightDiff && ( previousHeightDiff - pixelHeightDiff ) > 100 ){
-                            	String msg = "H";
+                                String msg = "H";
                                 result = new PluginResult(PluginResult.Status.OK, msg);
                                 result.setKeepCallback(true);
                                 callbackContext.sendPluginResult(result);
@@ -125,13 +126,7 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         private void possiblyResizeChildOfContent() {
                             int usableHeightNow = computeUsableHeight();
                             if (usableHeightNow != usableHeightPrevious) {
-                                int usableHeightSansKeyboard = mChildOfContent.getRootView().getHeight();
-                                int heightDifference = usableHeightSansKeyboard - usableHeightNow;
-                                if (heightDifference > (usableHeightSansKeyboard/4)) {
-                                    frameLayoutParams.height = usableHeightSansKeyboard - heightDifference;
-                                } else {
-                                    frameLayoutParams.height = usableHeightSansKeyboard;
-                                }
+                                frameLayoutParams.height = usableHeightNow;
                                 mChildOfContent.requestLayout();
                                 usableHeightPrevious = usableHeightNow;
                             }
@@ -140,7 +135,14 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         private int computeUsableHeight() {
                             Rect r = new Rect();
                             mChildOfContent.getWindowVisibleDisplayFrame(r);
-                            return (r.bottom - r.top);
+                            return isFullScreen() ? r.bottom - r.top + 55 : r.height();
+                        }
+
+                        private boolean isFullScreen() {
+                            final Window window = cordova.getActivity().getWindow();
+                            // Flag set by status bar plugin to make content full screen
+                            int fullScreenFlag = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                            return (window.getDecorView().getSystemUiVisibility() & fullScreenFlag) == fullScreenFlag;
                         }
                     };
 

--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -135,7 +135,7 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         private int computeUsableHeight() {
                             Rect r = new Rect();
                             mChildOfContent.getWindowVisibleDisplayFrame(r);
-                            return isFullScreen() ? r.bottom - r.top + 55 : r.height();
+                            return isFullScreen() ? r.bottom : r.height();
                         }
 
                         private boolean isFullScreen() {

--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -10,6 +10,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
 import android.graphics.Rect;
 import android.util.DisplayMetrics;
 import android.view.View;
@@ -22,7 +23,10 @@ import android.view.inputmethod.InputMethodManager;
 import android.view.Display;
 import android.graphics.Point;
 import android.os.Build;
+import android.webkit.WebView;
 import android.widget.FrameLayout;
+
+import timber.log.Timber;
 
 public class CDVIonicKeyboard extends CordovaPlugin {
     private OnGlobalLayoutListener list;
@@ -80,8 +84,17 @@ public class CDVIonicKeyboard extends CordovaPlugin {
                         public void onGlobalLayout() {
                             boolean resize = preferences.getBoolean("resizeOnFullScreen", false);
                             if (resize) {
-                                possiblyResizeChildOfContent();
+                                boolean webViewVersionLowerThan144 = getWebViewVersion() < 144;
+                                if (webViewVersionLowerThan144) {
+                                    possiblyResizeChildOfContent();
+                                    Timber.d("Resize content on older webview");
+                                } else {
+                                    // Known behaviour of extra footer space with recent webviews issue DEV-23290
+                                    // https://issues.chromium.org/issues/459087298
+                                    Timber.d("Webview greater or equal 144, dont resize");
+                                }
                             }
+
                             Rect r = new Rect();
                             //r will be populated with the coordinates of your view that area still visible.
                             rootView.getWindowVisibleDisplayFrame(r);
@@ -157,6 +170,22 @@ public class CDVIonicKeyboard extends CordovaPlugin {
             return true;
         }
         return false;  // Returning false results in a "MethodNotFound" error.
+    }
+
+    private int getWebViewVersion() {
+        try {
+            PackageInfo pkg = WebView.getCurrentWebViewPackage();
+            if (pkg == null || pkg.versionName == null) {
+                Timber.w("WebView package/version unavailable");
+                return 0;
+            }
+            Timber.d("WebView → Version: %s, Code: %d, Package: %s",
+                pkg.versionName, pkg.versionCode, pkg.packageName);
+            return Integer.parseInt(pkg.versionName.split("\\.")[0]);
+        } catch (Exception e) {
+            Timber.e(e, "Failed to read WebView version");
+            return 0; // safe fallback
+        }
     }
 
     @Override


### PR DESCRIPTION
**Description**
- It is being observed that with the updates to Webview (144 version), our app is showing extra space beneath the footer area. 
- Changes done to the plugin code as this does the resizing of the app which is not needed on the new versions of webview. 
- Thus did that resizing conditionally only for webview versions lower than 144.
- Dev tested on A7, A9, S5e and PCM and they work fine